### PR TITLE
Feature/view-leaderboard-dd

### DIFF
--- a/app/scripts/iron-pong.js
+++ b/app/scripts/iron-pong.js
@@ -2,7 +2,7 @@
 (function(){
   'use strict';
 
-  angular.module('iron-pong', ['ui.router', 'firebase', 'angularMoment'])
+  angular.module('iron-pong', ['ui.router', 'firebase', 'angularMoment', 'ngTable'])
 
     .config(function($stateProvider, $urlRouterProvider){
       $stateProvider
@@ -13,8 +13,8 @@
         }) // END $stateProvider recentresults
         .state('leaderboard', {
           url: '/leaderboard',
-          templateUrl: 'views/leaderboard.html'
-          // controller: 'LeaderboardController'
+          templateUrl: 'views/leaderboard.html',
+          controller: 'LeaderboardController'
         }) // END $stateProvider leaderboard
         .state('gameresult', {
           url: '/gameresult/:gameresultID',

--- a/app/scripts/iron-pong/leaderboard.controller.js
+++ b/app/scripts/iron-pong/leaderboard.controller.js
@@ -3,9 +3,9 @@
   'use strict';
 
   angular.module('iron-pong')
-    .controller('LeaderboardController', function($scope, $firebase, $firebaseArray){
+    .controller('LeaderboardController', function($scope, $filter, $firebase, $firebaseArray, ngTableParams){
 
-      $scope.players: [
+      $scope.players = [
         {avatar_url: 'http://lorempixel.com/120/120/people/1', login: 'sjoyal',
         wins: '55', losses: '14', pct: '.757', games: '69'},
         {avatar_url: 'http://lorempixel.com/120/120/people/2', login: 'pcreglow',
@@ -21,6 +21,19 @@
         {avatar_url: 'http://lorempixel.com/120/120/people/7', login: 'mstaehling',
         wins: '0', losses: '0', pct: '.000', games: '0'}
       ] // END $scope.players
+
+      $scope.tableParams = new ngTableParams({
+        sorting: {
+          login: 'asc'
+        }
+      }, {
+        total: $scope.players.length,
+        getData: function($defer, params){
+          var orderedData = params.sorting() ?
+            $filter('orderBy')($scope.players, params.orderBy()):
+            $scope.players;
+        }
+      });
 
       console.log($scope.players);
     }); // END LeaderboardController

--- a/app/scripts/iron-pong/leaderboard.controller.js
+++ b/app/scripts/iron-pong/leaderboard.controller.js
@@ -4,7 +4,25 @@
 
   angular.module('iron-pong')
     .controller('LeaderboardController', function($scope, $firebase, $firebaseArray){
-      console.log('hello');
+
+      $scope.players: [
+        {avatar_url: 'http://lorempixel.com/120/120/people/1', login: 'sjoyal',
+        wins: '55', losses: '14', pct: '.757', games: '69'},
+        {avatar_url: 'http://lorempixel.com/120/120/people/2', login: 'pcreglow',
+        wins: '40', losses: '30', pct: '.568', games: '70'},
+        {avatar_url: 'http://lorempixel.com/120/120/people/3', login: 'jorgehjr84',
+        wins: '8', losses: '40', pct: '.213', games: '48'},
+        {avatar_url: 'http://lorempixel.com/120/120/people/4', login: 'al-the-x',
+        wins: '0', losses: '125', pct: '.000', games: '125'},
+        {avatar_url: 'http://lorempixel.com/120/120/people/5', login: 'gatorpazz',
+        wins: '0', losses: '0', pct: '.000', games: '0'},
+        {avatar_url: 'http://lorempixel.com/120/120/people/6', login: 'jessyriordan',
+        wins: '0', losses: '0', pct: '.000', games: '0'},
+        {avatar_url: 'http://lorempixel.com/120/120/people/7', login: 'mstaehling',
+        wins: '0', losses: '0', pct: '.000', games: '0'}
+      ] // END $scope.players
+
+      console.log($scope.players);
     }); // END LeaderboardController
 
 

--- a/app/scripts/iron-pong/leaderboard.controller.js
+++ b/app/scripts/iron-pong/leaderboard.controller.js
@@ -24,7 +24,7 @@
 
       $scope.tableParams = new ngTableParams({
         sorting: {
-          login: 'asc'
+          wins: 'asc'
         }
       }, {
         total: $scope.players.length,
@@ -32,6 +32,9 @@
           var orderedData = params.sorting() ?
             $filter('orderBy')($scope.players, params.orderBy()):
             $scope.players;
+
+            $defer.resolve(orderedData.slice((params.page() - 1) * params.count(),
+              params.page() * params.count()));
         }
       });
 

--- a/app/scripts/iron-pong/leaderboard.controller.js
+++ b/app/scripts/iron-pong/leaderboard.controller.js
@@ -6,7 +6,7 @@
     .controller('LeaderboardController',
       function($scope, $filter, $firebase, $firebaseArray, ngTableParams){
 
-      var players = [
+      $scope.players = [
         {avatar_url: 'http://lorempixel.com/120/120/people/1', login: 'sjoyal',
         wins: '55', losses: '14', pct: '.757', games: '69'},
         {avatar_url: 'http://lorempixel.com/120/120/people/2', login: 'pcreglow',
@@ -25,11 +25,12 @@
 
       $scope.tableParams = new ngTableParams({
         sorting: {
-          wins: 'asc'  // initial sorting
+          wins: 'desc'  // initial sorting
         }
       }, {
         getData: function($defer, params){
-            $defer.resolve($filter('orderBy')(players, params.orderBy()));
+          var data = $scope.players;
+            $defer.resolve($filter('orderBy')(data, params.orderBy()));
         }
       });
     }); // END LeaderboardController

--- a/app/scripts/iron-pong/leaderboard.controller.js
+++ b/app/scripts/iron-pong/leaderboard.controller.js
@@ -1,0 +1,1 @@
+alert('allo allo');

--- a/app/scripts/iron-pong/leaderboard.controller.js
+++ b/app/scripts/iron-pong/leaderboard.controller.js
@@ -6,34 +6,34 @@
     .controller('LeaderboardController',
       function($scope, $filter, $firebase, $firebaseArray, ngTableParams){
 
-      $scope.players = [
-        {avatar_url: 'http://lorempixel.com/120/120/people/1', login: 'sjoyal',
-        wins: '55', losses: '14', pct: '.757', games: '69'},
-        {avatar_url: 'http://lorempixel.com/120/120/people/2', login: 'pcreglow',
-        wins: '40', losses: '30', pct: '.568', games: '70'},
-        {avatar_url: 'http://lorempixel.com/120/120/people/3', login: 'jorgehjr84',
-        wins: '8', losses: '40', pct: '.213', games: '48'},
-        {avatar_url: 'http://lorempixel.com/120/120/people/4', login: 'al-the-x',
-        wins: '0', losses: '125', pct: '.000', games: '125'},
-        {avatar_url: 'http://lorempixel.com/120/120/people/5', login: 'gatorpazz',
-        wins: '0', losses: '0', pct: '.000', games: '0'},
-        {avatar_url: 'http://lorempixel.com/120/120/people/6', login: 'jessyriordan',
-        wins: '0', losses: '0', pct: '.000', games: '0'},
-        {avatar_url: 'http://lorempixel.com/120/120/people/7', login: 'mstaehling',
-        wins: '0', losses: '0', pct: '.000', games: '0'}
-      ] // END players
+        $scope.players = [
+          {avatar_url: 'http://lorempixel.com/120/120/people/1', login: 'sjoyal',
+          wins: 55, losses: 14, pct: .757, games: 69},
+          {avatar_url: 'http://lorempixel.com/120/120/people/2', login: 'pcreglow',
+          wins: 40, losses: 30, pct: .568, games: 70},
+          {avatar_url: 'http://lorempixel.com/120/120/people/3', login: 'jorgehjr84',
+          wins: 8, losses: 40, pct: .213, games: 48},
+          {avatar_url: 'http://lorempixel.com/120/120/people/5', login: 'gatorpazz',
+          wins: 0, losses: 0, pct: .000, games: 0},
+          {avatar_url: 'http://lorempixel.com/120/120/people/6', login: 'jessyriordan',
+          wins: 0, losses: 0, pct: .000, games: 0},
+          {avatar_url: 'http://lorempixel.com/120/120/people/7', login: 'mstaehling',
+          wins: 0, losses: 0, pct: .000, games: 0},
+          {avatar_url: 'http://lorempixel.com/120/120/people/4', login: 'al-the-x',
+          wins: 0, losses: 125, pct: .000, games: 125}
+        ] // END players
 
-      $scope.tableParams = new ngTableParams({
-        sorting: {
-          wins: 'desc'  // initial sorting
-        }
-      }, {
-        getData: function($defer, params){
-          var data = $scope.players;
-            $defer.resolve($filter('orderBy')(data, params.orderBy()));
-        }
-      });
-    }); // END LeaderboardController
+        $scope.tableParams = new ngTableParams({
+          sorting: {
+            wins: 'desc'  // initial sorting
+          }
+        }, {
+          getData: function($defer, params){
+            $scope.players = $filter('orderBy')($scope.players, params.orderBy());
+              $defer.resolve($scope.players);
+          }
+        });
+      }); // END LeaderboardController
 
 
 })();

--- a/app/scripts/iron-pong/leaderboard.controller.js
+++ b/app/scripts/iron-pong/leaderboard.controller.js
@@ -1,1 +1,11 @@
-alert('allo allo');
+/* global angular Firebase */
+(function(){
+  'use strict';
+
+  angular.module('iron-pong')
+    .controller('LeaderboardController', function($scope, $firebase, $firebaseArray){
+      console.log('hello');
+    }); // END LeaderboardController
+
+
+})();

--- a/app/scripts/iron-pong/leaderboard.controller.js
+++ b/app/scripts/iron-pong/leaderboard.controller.js
@@ -3,9 +3,10 @@
   'use strict';
 
   angular.module('iron-pong')
-    .controller('LeaderboardController', function($scope, $filter, $firebase, $firebaseArray, ngTableParams){
+    .controller('LeaderboardController',
+      function($scope, $filter, $firebase, $firebaseArray, ngTableParams){
 
-      $scope.players = [
+      var players = [
         {avatar_url: 'http://lorempixel.com/120/120/people/1', login: 'sjoyal',
         wins: '55', losses: '14', pct: '.757', games: '69'},
         {avatar_url: 'http://lorempixel.com/120/120/people/2', login: 'pcreglow',
@@ -20,25 +21,17 @@
         wins: '0', losses: '0', pct: '.000', games: '0'},
         {avatar_url: 'http://lorempixel.com/120/120/people/7', login: 'mstaehling',
         wins: '0', losses: '0', pct: '.000', games: '0'}
-      ] // END $scope.players
+      ] // END players
 
       $scope.tableParams = new ngTableParams({
         sorting: {
-          wins: 'asc'
+          wins: 'asc'  // initial sorting
         }
       }, {
-        total: $scope.players.length,
         getData: function($defer, params){
-          var orderedData = params.sorting() ?
-            $filter('orderBy')($scope.players, params.orderBy()):
-            $scope.players;
-
-            $defer.resolve(orderedData.slice((params.page() - 1) * params.count(),
-              params.page() * params.count()));
+            $defer.resolve($filter('orderBy')(players, params.orderBy()));
         }
       });
-
-      console.log($scope.players);
     }); // END LeaderboardController
 
 

--- a/app/views/leaderboard.html
+++ b/app/views/leaderboard.html
@@ -1,5 +1,5 @@
 <section class="table-section table-responsive">
-  <table class="table player-stats">
+  <table class="table player-stats" ng-table="tableParams">
     <thead>
       <tr>
           <th class="player-login">Player</th>
@@ -10,7 +10,7 @@
       </tr>
     </thead>
     <tbody>
-      <tr>
+      <tr ng-repeat="player in players">
         <td class="player-login">
           <img width="30" height="30" src=http://lorempixel.com/120/120/people/7/>
           sjoyal

--- a/app/views/leaderboard.html
+++ b/app/views/leaderboard.html
@@ -1,27 +1,27 @@
 <section class="table-section table-responsive">
   <table class="table player-stats" ng-table="tableParams">
-    <thead>
+    <!-- <thead>
       <tr>
-          <th class="player-login">Player</th>
-          <th>Wins</th>
-          <th>Losses</th>
-          <th>Win %</th>
-          <th>Games</th>
+        <th class="player-login">Player</th>
+        <th>Wins</th>
+        <th>Losses</th>
+        <th>Win %</th>
+        <th>Games</th>
       </tr>
     </thead>
-    <tbody>
-      <tr ng-repeat="player in players">
+    <tbody> -->
+      <tr ng-repeat="player in $data">
         <td class="player-login">
           <img width="30" height="30" ng-src="{{player.avatar_url}}"/>
           {{player.login}}
         </td>
         <td data-title="'Wins'" sortable="'wins'">{{player.wins}}</td>
-        <td>{{player.losses}}</td>
-        <td>{{player.pct}}</td>
-        <td>{{player.games}}</td>
+        <td data-title="'Losses'" sortable="'losses'">{{player.losses}}</td>
+        <td data-title="'Win %'" sortable="'pct'">{{player.pct}}</td>
+        <td data-title="'Games'" sortable="'games'">{{player.games}}</td>
       </tr>
-      <tr>
-      <!--   <td class="player-login">
+    <!--   <tr>
+      <td class="player-login">
         <img width="30" height="30" src="http://lorempixel.com/120/120/people/1"/>
         pcreglow
       </td>
@@ -29,8 +29,8 @@
       <td>30</td>
       <td>.568</td>
       <td>70</td>
-            </tr>
-            <tr>
+    </tr>
+    <tr>
       <td class="player-login">
         <img width="30" height="30" src="http://lorempixel.com/120/120/people/2"/>
         jorgehjr84
@@ -39,8 +39,8 @@
       <td>40</td>
       <td>.213</td>
       <td>48</td>
-            </tr>
-            <tr>
+    </tr>
+    <tr>
       <td class="player-login">
         <img width="30" height="30" src="http://lorempixel.com/120/120/people/3"/>
         al-the-x
@@ -49,8 +49,8 @@
       <td>125</td>
       <td>.000</td>
       <td>125</td>
-            </tr>
-            <tr>
+    </tr>
+    <tr>
       <td class="player-login">
         <img width="30" height="30" src="http://lorempixel.com/120/120/people/4"/>
         gatorpazz
@@ -59,8 +59,8 @@
       <td>0</td>
       <td>.000</td>
       <td>0</td>
-            </tr>
-            <tr>
+    </tr>
+    <tr>
       <td class="player-login">
         <img width="30" height="30" src="http://lorempixel.com/120/120/people/5"/>
         jessyriordan
@@ -69,8 +69,8 @@
       <td>0</td>
       <td>.000</td>
       <td>0</td>
-            </tr>
-            <tr>
+    </tr>
+    <tr>
       <td class="player-login">
         <img width="30" height="30" src="http://lorempixel.com/120/120/people/6"/>
         mstaehling
@@ -79,7 +79,7 @@
       <td>0</td>
       <td>.000</td>
       <td>0</td>
-            </tr> -->
-    </tbody>
+    </tr>
+        </tbody> -->
   </table><!-- .table -->
 </section><!--.table-section-->

--- a/app/views/leaderboard.html
+++ b/app/views/leaderboard.html
@@ -12,74 +12,74 @@
     <tbody>
       <tr ng-repeat="player in players">
         <td class="player-login">
-          <img width="30" height="30" src=http://lorempixel.com/120/120/people/7/>
-          sjoyal
+          <img width="30" height="30" ng-src="{{player.avatar_url}}"/>
+          {{player.login}}
         </td>
-        <td>55</td>
-        <td>14</td>
-        <td>.757</td>
-        <td>69</td>
+        <td data-title="'Wins'" sortable="'wins'">{{player.wins}}</td>
+        <td>{{player.losses}}</td>
+        <td>{{player.pct}}</td>
+        <td>{{player.games}}</td>
       </tr>
       <tr>
-        <td class="player-login">
-          <img width="30" height="30" src=http://lorempixel.com/120/120/people/1/>
-          pcreglow
-        </td>
-        <td>40</td>
-        <td>30</td>
-        <td>.568</td>
-        <td>70</td>
-      </tr>
-      <tr>
-        <td class="player-login">
-          <img width="30" height="30" src=http://lorempixel.com/120/120/people/2/>
-          jorgehjr84
-        </td>
-        <td>8</td>
-        <td>40</td>
-        <td>.213</td>
-        <td>48</td>
-      </tr>
-      <tr>
-        <td class="player-login">
-          <img width="30" height="30" src=http://lorempixel.com/120/120/people/3/>
-          al-the-x
-        </td>
-        <td>0</td>
-        <td>125</td>
-        <td>.000</td>
-        <td>125</td>
-      </tr>
-      <tr>
-        <td class="player-login">
-          <img width="30" height="30" src=http://lorempixel.com/120/120/people/4/>
-          gatorpazz
-        </td>
-        <td>0</td>
-        <td>0</td>
-        <td>.000</td>
-        <td>0</td>
-      </tr>
-      <tr>
-        <td class="player-login">
-          <img width="30" height="30" src=http://lorempixel.com/120/120/people/5/>
-          jessyriordan
-        </td>
-        <td>0</td>
-        <td>0</td>
-        <td>.000</td>
-        <td>0</td>
-      </tr>
-      <tr>
-        <td class="player-login">
-          <img width="30" height="30" src=http://lorempixel.com/120/120/people/6/>
-          mstaehling
-        </td>
-        <td>0</td>
-        <td>0</td>
-        <td>.000</td>
-        <td>0</td>
-      </tr>
+      <!--   <td class="player-login">
+        <img width="30" height="30" src="http://lorempixel.com/120/120/people/1"/>
+        pcreglow
+      </td>
+      <td>40</td>
+      <td>30</td>
+      <td>.568</td>
+      <td>70</td>
+            </tr>
+            <tr>
+      <td class="player-login">
+        <img width="30" height="30" src="http://lorempixel.com/120/120/people/2"/>
+        jorgehjr84
+      </td>
+      <td>8</td>
+      <td>40</td>
+      <td>.213</td>
+      <td>48</td>
+            </tr>
+            <tr>
+      <td class="player-login">
+        <img width="30" height="30" src="http://lorempixel.com/120/120/people/3"/>
+        al-the-x
+      </td>
+      <td>0</td>
+      <td>125</td>
+      <td>.000</td>
+      <td>125</td>
+            </tr>
+            <tr>
+      <td class="player-login">
+        <img width="30" height="30" src="http://lorempixel.com/120/120/people/4"/>
+        gatorpazz
+      </td>
+      <td>0</td>
+      <td>0</td>
+      <td>.000</td>
+      <td>0</td>
+            </tr>
+            <tr>
+      <td class="player-login">
+        <img width="30" height="30" src="http://lorempixel.com/120/120/people/5"/>
+        jessyriordan
+      </td>
+      <td>0</td>
+      <td>0</td>
+      <td>.000</td>
+      <td>0</td>
+            </tr>
+            <tr>
+      <td class="player-login">
+        <img width="30" height="30" src="http://lorempixel.com/120/120/people/6"/>
+        mstaehling
+      </td>
+      <td>0</td>
+      <td>0</td>
+      <td>.000</td>
+      <td>0</td>
+            </tr> -->
     </tbody>
   </table><!-- .table -->
 </section><!--.table-section-->

--- a/app/views/leaderboard.html
+++ b/app/views/leaderboard.html
@@ -1,14 +1,5 @@
 <section class="table-section table-responsive">
   <table class="table player-stats" ng-table="tableParams">
-    <!--     <thead>
-      <tr>
-        <th class="player-login">Player</th>
-        <th>Wins</th>
-        <th>Losses</th>
-        <th>Win %</th>
-        <th>Games</th>
-      </tr>
-    </thead> -->
     <tbody>
       <tr ng-repeat="player in players">
         <td class="player-login">
@@ -20,66 +11,87 @@
         <td data-title="'pct'" sortable="'pct'">{{player.pct}}</td>
         <td data-title="'games'" sortable="'games'">{{player.games}}</td>
       </tr>
-      <!-- <tr>
-        <td class="player-login">
-          <img width="30" height="30" src="http://lorempixel.com/120/120/people/1"/>
-          pcreglow
-        </td>
-        <td>40</td>
-        <td>30</td>
-        <td>.568</td>
-        <td>70</td>
-      </tr>
-      <tr>
-        <td class="player-login">
-          <img width="30" height="30" src="http://lorempixel.com/120/120/people/2"/>
-          jorgehjr84
-        </td>
-        <td>8</td>
-        <td>40</td>
-        <td>.213</td>
-        <td>48</td>
-      </tr>
-      <tr>
-        <td class="player-login">
-          <img width="30" height="30" src="http://lorempixel.com/120/120/people/3"/>
-          al-the-x
-        </td>
-        <td>0</td>
-        <td>125</td>
-        <td>.000</td>
-        <td>125</td>
-      </tr>
-      <tr>
-        <td class="player-login">
-          <img width="30" height="30" src="http://lorempixel.com/120/120/people/4"/>
-          gatorpazz
-        </td>
-        <td>0</td>
-        <td>0</td>
-        <td>.000</td>
-        <td>0</td>
-      </tr>
-      <tr>
-        <td class="player-login">
-          <img width="30" height="30" src="http://lorempixel.com/120/120/people/5"/>
-          jessyriordan
-        </td>
-        <td>0</td>
-        <td>0</td>
-        <td>.000</td>
-        <td>0</td>
-      </tr>
-      <tr>
-        <td class="player-login">
-          <img width="30" height="30" src="http://lorempixel.com/120/120/people/6"/>
-          mstaehling
-        </td>
-        <td>0</td>
-        <td>0</td>
-        <td>.000</td>
-        <td>0</td>
-      </tr> -->
     </tbody>
   </table><!-- .table -->
 </section><!--.table-section-->
+
+  <!-- <thead>
+  <tr>
+    <th class="player-login">Player</th>
+    <th>Wins</th>
+    <th>Losses</th>
+    <th>Win %</th>
+    <th>Games</th>
+  </tr>
+  </thead> -->
+  <!-- <tbody>
+  <tr ng-repeat="player in players">
+    <td class="player-login">
+      <img width="30" height="30" ng-src="{{player.avatar_url}}"/>
+      {{player.login}}
+    </td>
+    <td data-title="'wins'" sortable="'wins'">{{player.wins}}</td>
+    <td data-title="'losses'" sortable="'losses'">{{player.losses}}</td>
+    <td data-title="'pct'" sortable="'pct'">{{player.pct}}</td>
+    <td data-title="'games'" sortable="'games'">{{player.games}}</td>
+  </tr> -->
+  <!-- <tr>
+    <td class="player-login">
+      <img width="30" height="30" src="http://lorempixel.com/120/120/people/1"/>
+      pcreglow
+    </td>
+    <td>40</td>
+    <td>30</td>
+    <td>.568</td>
+    <td>70</td>
+  </tr>
+  <tr>
+    <td class="player-login">
+      <img width="30" height="30" src="http://lorempixel.com/120/120/people/2"/>
+      jorgehjr84
+    </td>
+    <td>8</td>
+    <td>40</td>
+    <td>.213</td>
+    <td>48</td>
+  </tr>
+  <tr>
+    <td class="player-login">
+      <img width="30" height="30" src="http://lorempixel.com/120/120/people/3"/>
+      al-the-x
+    </td>
+    <td>0</td>
+    <td>125</td>
+    <td>.000</td>
+    <td>125</td>
+  </tr>
+  <tr>
+    <td class="player-login">
+      <img width="30" height="30" src="http://lorempixel.com/120/120/people/4"/>
+      gatorpazz
+    </td>
+    <td>0</td>
+    <td>0</td>
+    <td>.000</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td class="player-login">
+      <img width="30" height="30" src="http://lorempixel.com/120/120/people/5"/>
+      jessyriordan
+    </td>
+    <td>0</td>
+    <td>0</td>
+    <td>.000</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td class="player-login">
+      <img width="30" height="30" src="http://lorempixel.com/120/120/people/6"/>
+      mstaehling
+    </td>
+    <td>0</td>
+    <td>0</td>
+    <td>.000</td>
+    <td>0</td>
+  </tr> -->

--- a/app/views/leaderboard.html
+++ b/app/views/leaderboard.html
@@ -1,6 +1,6 @@
 <section class="table-section table-responsive">
   <table class="table player-stats" ng-table="tableParams">
-    <!-- <thead>
+    <!--     <thead>
       <tr>
         <th class="player-login">Player</th>
         <th>Wins</th>
@@ -8,78 +8,78 @@
         <th>Win %</th>
         <th>Games</th>
       </tr>
-    </thead>
-    <tbody> -->
-      <tr ng-repeat="player in $data">
+    </thead> -->
+    <tbody>
+      <tr ng-repeat="player in players">
         <td class="player-login">
           <img width="30" height="30" ng-src="{{player.avatar_url}}"/>
           {{player.login}}
         </td>
-        <td data-title="'Wins'" sortable="'wins'">{{player.wins}}</td>
-        <td data-title="'Losses'" sortable="'losses'">{{player.losses}}</td>
-        <td data-title="'Win %'" sortable="'pct'">{{player.pct}}</td>
-        <td data-title="'Games'" sortable="'games'">{{player.games}}</td>
+        <td data-title="'wins'" sortable="'wins'">{{player.wins}}</td>
+        <td data-title="'losses'" sortable="'losses'">{{player.losses}}</td>
+        <td data-title="'pct'" sortable="'pct'">{{player.pct}}</td>
+        <td data-title="'games'" sortable="'games'">{{player.games}}</td>
       </tr>
-    <!--   <tr>
-      <td class="player-login">
-        <img width="30" height="30" src="http://lorempixel.com/120/120/people/1"/>
-        pcreglow
-      </td>
-      <td>40</td>
-      <td>30</td>
-      <td>.568</td>
-      <td>70</td>
-    </tr>
-    <tr>
-      <td class="player-login">
-        <img width="30" height="30" src="http://lorempixel.com/120/120/people/2"/>
-        jorgehjr84
-      </td>
-      <td>8</td>
-      <td>40</td>
-      <td>.213</td>
-      <td>48</td>
-    </tr>
-    <tr>
-      <td class="player-login">
-        <img width="30" height="30" src="http://lorempixel.com/120/120/people/3"/>
-        al-the-x
-      </td>
-      <td>0</td>
-      <td>125</td>
-      <td>.000</td>
-      <td>125</td>
-    </tr>
-    <tr>
-      <td class="player-login">
-        <img width="30" height="30" src="http://lorempixel.com/120/120/people/4"/>
-        gatorpazz
-      </td>
-      <td>0</td>
-      <td>0</td>
-      <td>.000</td>
-      <td>0</td>
-    </tr>
-    <tr>
-      <td class="player-login">
-        <img width="30" height="30" src="http://lorempixel.com/120/120/people/5"/>
-        jessyriordan
-      </td>
-      <td>0</td>
-      <td>0</td>
-      <td>.000</td>
-      <td>0</td>
-    </tr>
-    <tr>
-      <td class="player-login">
-        <img width="30" height="30" src="http://lorempixel.com/120/120/people/6"/>
-        mstaehling
-      </td>
-      <td>0</td>
-      <td>0</td>
-      <td>.000</td>
-      <td>0</td>
-    </tr>
-        </tbody> -->
+      <!-- <tr>
+        <td class="player-login">
+          <img width="30" height="30" src="http://lorempixel.com/120/120/people/1"/>
+          pcreglow
+        </td>
+        <td>40</td>
+        <td>30</td>
+        <td>.568</td>
+        <td>70</td>
+      </tr>
+      <tr>
+        <td class="player-login">
+          <img width="30" height="30" src="http://lorempixel.com/120/120/people/2"/>
+          jorgehjr84
+        </td>
+        <td>8</td>
+        <td>40</td>
+        <td>.213</td>
+        <td>48</td>
+      </tr>
+      <tr>
+        <td class="player-login">
+          <img width="30" height="30" src="http://lorempixel.com/120/120/people/3"/>
+          al-the-x
+        </td>
+        <td>0</td>
+        <td>125</td>
+        <td>.000</td>
+        <td>125</td>
+      </tr>
+      <tr>
+        <td class="player-login">
+          <img width="30" height="30" src="http://lorempixel.com/120/120/people/4"/>
+          gatorpazz
+        </td>
+        <td>0</td>
+        <td>0</td>
+        <td>.000</td>
+        <td>0</td>
+      </tr>
+      <tr>
+        <td class="player-login">
+          <img width="30" height="30" src="http://lorempixel.com/120/120/people/5"/>
+          jessyriordan
+        </td>
+        <td>0</td>
+        <td>0</td>
+        <td>.000</td>
+        <td>0</td>
+      </tr>
+      <tr>
+        <td class="player-login">
+          <img width="30" height="30" src="http://lorempixel.com/120/120/people/6"/>
+          mstaehling
+        </td>
+        <td>0</td>
+        <td>0</td>
+        <td>.000</td>
+        <td>0</td>
+      </tr> -->
+    </tbody>
   </table><!-- .table -->
 </section><!--.table-section-->


### PR DESCRIPTION
- [x] populate `views/leaderboard.html` with dummy data (literal in controller):
  - [x] leaderboard of players and associated stats
    - [x] order players by # of wins (orderBy?)
- [x] leaderboard should be sortable by clicking column headings
- [x] research how to update tabular player data after click without complete partial refresh and using another angular filter
  - ng-table?
- [x] leaderboard should sort based on wins (W), losses (L), win pct (WP %), and games played (GP)
